### PR TITLE
feat(other): transform all files not only those in the public folder

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -29,7 +29,7 @@ const extRE = /\.(png|jpeg|jpg|gif|bmp|svg|webp)$/i
 
 export default function (options: VuePressPluginImageminOption = {}): Plugin {
   let outputPath: string
-  let publicDir: string
+  let inputPath: string
   // let config: ResolvedConfig
 
   const { disable = false, include, exclude, verbose = true } = options
@@ -109,8 +109,8 @@ export default function (options: VuePressPluginImageminOption = {}): Plugin {
     enforce: 'post',
     onPrepared(app: App) {
       outputPath = app.dir.dest()
-      publicDir = app.dir.public()
-      debug({ outputPath, publicDir })
+      inputPath = app.dir.dest()
+      debug({ outputPath, inputPath })
     },
     // async generateBundle(_, bundler) {
     //   tinyMap.clear()
@@ -139,20 +139,20 @@ export default function (options: VuePressPluginImageminOption = {}): Plugin {
     async onGenerated() {
       debug('onGenerated')
 
-      if (publicDir) {
+      if (inputPath) {
         const files: string[] = []
 
         // try to find any static images in original static folder
-        readAllFiles(publicDir).forEach((file) => {
+        readAllFiles(inputPath).forEach((file) => {
           filterFile(file) && files.push(file)
         })
 
         debug({ files })
 
         if (files.length) {
-          const handles = files.map(async (publicFilePath: string) => {
+          const handles = files.map(async (inputFilePath: string) => {
             // now convert the path to the output folder
-            const filePath = path.relative(publicDir, publicFilePath)
+            const filePath = path.relative(inputPath, inputFilePath)
             const fullFilePath = path.join(outputPath, filePath)
 
             debug({ filePath, fullFilePath })


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

In order to transform files located outside the public folder we transform all images inside the destination folder.

### Linked Issues

**Issues are disabled in this Repo!**

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Vuepress advises to link images next to the documentation files. This is outside the public folder. Hence this plugin doesn't compress those files.

With this change all images files inside the dist folder are compress, which seem more appropriate

Here an output in the corresponding project:
![image](https://github.com/user-attachments/assets/34be136f-5c4b-4579-8d24-4b82f10c56c9)
 See: https://github.com/IT4Change/IT4C.dev/pull/259
 
 Output without the change:
![image](https://github.com/user-attachments/assets/6a0e0852-7a4f-4c08-b04f-89549853f249)
